### PR TITLE
Fix current page indicator

### DIFF
--- a/src/app/[lang]/components/MobileNavigation/index.tsx
+++ b/src/app/[lang]/components/MobileNavigation/index.tsx
@@ -4,7 +4,7 @@ import NavTab from '../NavTab'
 import NavLink from '../NavLink'
 import styles from './styles.module.scss'
 import LanguageSwitcher from '../LanguageSwitcher'
-import { checkIsCurrent, getSlugFromPathname } from '@/util/navigationUtils'
+import { checkIsCurrent } from '@/util/navigationUtils'
 import { usePathname } from 'next/navigation'
 import { NavigationData, PageTabs } from '../Navigation'
 import { Locales } from '@/i18n'
@@ -22,7 +22,6 @@ export default function MobileNavigation({
 	const [isOpen, setIsOpen] = useState(false)
 	const toggle = () => setIsOpen(!isOpen)
 	const pathname = usePathname()
-	const slug = getSlugFromPathname(pathname)
 
 	return (
 		<>
@@ -57,7 +56,7 @@ export default function MobileNavigation({
 										<NavLink
 											key={page.text}
 											hidden={!isTabOpen}
-											isCurrent={checkIsCurrent(page, slug)}
+											isCurrent={checkIsCurrent(page.href, pathname)}
 											mobileToggle={toggle}
 											href={page.href}
 											text={page.text}

--- a/src/app/[lang]/components/NavLinks/index.tsx
+++ b/src/app/[lang]/components/NavLinks/index.tsx
@@ -3,7 +3,7 @@ import NavLink from '../NavLink'
 import styles from './styles.module.scss'
 import { useState } from 'react'
 import NavTab from '../NavTab'
-import { checkIsCurrent, getSlugFromPathname } from '@/util/navigationUtils'
+import { checkIsCurrent } from '@/util/navigationUtils'
 import { usePathname } from 'next/navigation'
 import { NavigationData, PageTabs } from '../Navigation'
 
@@ -14,7 +14,6 @@ export default function NavLinks({
 }) {
 	const [toggledTab, setToggledTab] = useState<string | null>(null)
 	const pathname = usePathname()
-	const slug = getSlugFromPathname(pathname)
 
 	const orderOfNav = Object.keys(navigation)
 		.filter(key => key !== 'title')
@@ -53,7 +52,7 @@ export default function NavLinks({
 								<NavLink
 									key={page.text}
 									hidden={!isOpen}
-									isCurrent={checkIsCurrent(page, slug)}
+									isCurrent={checkIsCurrent(page.href, pathname)}
 									href={page.href}
 									text={page.text}
 								/>

--- a/src/util/navigationUtils.ts
+++ b/src/util/navigationUtils.ts
@@ -1,7 +1,7 @@
 export const checkIsCurrent = (page: string, current: string) => {
 	if (current === '/' && page === 'home') {
 		return true
-	} else if (page === current.slice(1)) {
+	} else if (page === current) {
 		return true
 	}
 	return false


### PR DESCRIPTION
This fixes the 'current page' indicator in the navigation, so that the current page is indicated and stops being a hyperlink.

Essentially, we were assuming that `page` was a string, but it's actually an object with the page's relative URL in the `href` attribute.

<img width="620" height="688" alt="Screenshot From 2026-02-07 21-01-59" src="https://github.com/user-attachments/assets/405d35ac-c22f-4521-ac56-62aee6fca4e6" />
