### PR TITLE
Auto-open relevant navigation tab

### DIFF
--- a/src/app/[lang]/components/NavLinks/index.tsx
+++ b/src/app/[lang]/components/NavLinks/index.tsx
@@ -7,13 +7,39 @@ import { checkIsCurrent, getSlugFromPathname } from '@/util/navigationUtils'
 import { usePathname } from 'next/navigation'
 import { NavigationData, PageTabs } from '../Navigation'
 
+function getDefaultToggledTab(pathname: string, navigation: string[]) {
+	// When the user starts browsing, we need to figure out which navigation
+	// section to have expanded. This applies only when the user loads a page
+	// directly, coming from an external source.
+	//
+	// If the user is viewing a page related to a specific event year, we should
+	// expand that year's navigation section.
+	const yearInPathname = pathname.match(/\d{4}/)
+	if (yearInPathname != null && yearInPathname.length > 0) {
+		const matchingKeys = navigation.filter(key => key.includes(yearInPathname[0]))
+		if (matchingKeys.length == 1) {
+			return matchingKeys[0]
+		}
+	// If the user is on the homepage, we should expand the navigation section
+	// for the most recent event (to make the details more discoverable).
+	} else if (pathname == "/en" || pathname == "/fr") {
+		return navigation.filter(
+			key => /\d{4}/.test(key)
+		).sort().reverse()[0] ?? null
+	}
+	// For all other situations, we won't expand any tab by default.
+	return null
+}
+
 export default function NavLinks({
 	navigation,
 }: {
 	navigation: NavigationData
 }) {
-	const [toggledTab, setToggledTab] = useState<string | null>(null)
 	const pathname = usePathname()
+	const [toggledTab, setToggledTab] = useState<string | null>(
+		getDefaultToggledTab(pathname, Object.keys(navigation))
+	)
 	const slug = getSlugFromPathname(pathname)
 
 	const orderOfNav = Object.keys(navigation)


### PR DESCRIPTION
When a user arrives on the Bal Jam website from an external source (search engine, message, email, etc), the navigation bar is completely collapsed. I think this makes it more difficult to discover the event details.

<img width="2342" height="694" alt="image" src="https://github.com/user-attachments/assets/2f43fdf3-c749-4b36-b6b8-344960ab0ac1" />

In this PR, I've added some logic to automatically open a navigation section when the user first arrives on the website, according to the following rules:

- if the page is associated with a particular event year (e.g. 2025 instructors page), open the navigation section for that year's event
- if we're on the homepage, always expand the navigation section for the latest event
- otherwise, don't automatically expand any navigation section

With this update, it will be easier for users to find the information for the current Bal Jam event:

<img width="2342" height="694" alt="image" src="https://github.com/user-attachments/assets/1dd87e44-a308-4940-b9cf-130835c5f2bf" />

Again, this logic only applies when the user first arrives on the website. Once they start browsing on the site, the existing tab logic will be used.

(Note: there will probably be a merge conflict with https://github.com/FelixPriori/mtlbaljam/pull/12, I can update this PR when that's merged)