### PR TITLE
Auto-open relevant navigation tab

### DIFF
--- a/src/app/[lang]/components/NavLinks/index.tsx
+++ b/src/app/[lang]/components/NavLinks/index.tsx
@@ -3,7 +3,7 @@ import NavLink from '../NavLink'
 import styles from './styles.module.scss'
 import { useState } from 'react'
 import NavTab from '../NavTab'
-import { checkIsCurrent } from '@/util/navigationUtils'
+import { checkIsCurrent, getDefaultToggledTab } from '@/util/navigationUtils'
 import { usePathname } from 'next/navigation'
 import { NavigationData, PageTabs } from '../Navigation'
 
@@ -12,9 +12,10 @@ export default function NavLinks({
 }: {
 	navigation: NavigationData
 }) {
-	const [toggledTab, setToggledTab] = useState<string | null>(null)
 	const pathname = usePathname()
-
+	const [toggledTab, setToggledTab] = useState<string | null>(
+		getDefaultToggledTab(pathname, navigation)
+	)
 	const orderOfNav = Object.keys(navigation)
 		.filter(key => key !== 'title')
 		.sort((a, b) => {

--- a/src/util/navigationUtils.ts
+++ b/src/util/navigationUtils.ts
@@ -1,3 +1,5 @@
+import { NavigationData } from '../app/[lang]/components/Navigation'
+
 export const checkIsCurrent = (page: string, current: string) => {
 	if (current === '/' && page === 'home') {
 		return true
@@ -24,4 +26,30 @@ export const getSlugFromPathname = (pathname: string) => {
 export const getPageNameFromSlug = (pathname: string) => {
 	const slug = getSlugFromPathname(pathname)
 	return slug.slice(1)
+}
+
+// When the user starts browsing, we need to figure out which navigation
+// section to have expanded. This applies only when the user loads a page
+// directly, coming from an external source.
+export const getDefaultToggledTab = (pathname: string, navigation: NavigationData) => {
+	// If the user is on the homepage, we should expand the navigation section
+	// for the most recent event (to make the details more discoverable).
+	if (pathname === "/en" || pathname === "/fr") {
+		return Object.keys(navigation).filter(
+			key => /\d{4}/.test(key)
+		).sort().reverse()[0] ?? null
+	}
+	// Otherwise, figure out which tab should be expanded, based on the current
+	// page.
+	for (const [key, value] of Object.entries(navigation)) {
+		if (typeof value === 'object' && 'subtabs' in value) {
+			for (const tab of value.subtabs) {
+				if (tab.href == pathname) {
+					return key
+				}
+			}
+		}
+	}
+	// For any other situation, don't expand any tab by default.
+	return null;
 }


### PR DESCRIPTION
This is a re-do of #13 (I didn't intend to close it, but Github did that when I deleted my fork of this repository).

When a user arrives on the site from an external source, we'll now auto-open the correct navigation tab. If they're on the homepage, we'll open the tab for the current event year.